### PR TITLE
[DEVOPS-XX] Fix issue missing libzlib.so

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,8 +19,8 @@ cmake(
     out_shared_libs = [
         "libzip.so.5",
     ],
-    deps = [ 
-        "@zlib",
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@net_zlib_zlib//:zlib",
+    ],
 )


### PR DESCRIPTION
Changelog
===

Bazel rostests are failing since `libzlib.so` file cannot be found like below.

```
test_online_slam: error while loading shared libraries: /dev/shm/bazel-sandbox.645578b439a1504478369621a4f283f730e3e1a58f920f0a1b6a63bb93a808af/linux-sandbox/26/execroot/bear_platform/bazel-out/k8-fastbuild/bin/external/libzip/zip.ext_build_deps/lib/libzlib.so: cannot open shared object file: No such file or directory
```

Replace `@zlib` with `@net_zlib_zlib`, which is [used by rules_boost](https://github.com/bearrobotics/rules_boost/blob/99e9ba3b4e14faac3c1f92529c8d78dc76333ef3/BUILD.zlib) and other rules.


Testing
===

Run `bazel test //ROS/third_party/navigation/amcl/...`